### PR TITLE
[FIX] compatibility issue with urllib3 v2.0 and OpenSSL

### DIFF
--- a/chapter10/10_commands.txt
+++ b/chapter10/10_commands.txt
@@ -24,6 +24,7 @@ sudo yum -y install python3
 python3 -m venv venv10
 source venv10/bin/activate
 pip install confluent-kafka[avro]
+pip install urllib3==1.26.6
 
 P342
 python python-avro-producer.py


### PR DESCRIPTION
예제 10-4 python 을 실행하면서 openssl 버전과 urllib3 의 호환성을 맞추기 위해 명령줄을 추가합니다. 

참고 :https://stackoverflow.com/questions/76187256/importerror-urllib3-v2-0-only-supports-openssl-1-1-1-currently-the-ssl-modu